### PR TITLE
Use replica count 1 as this controller is not critical

### DIFF
--- a/stable/volsync-addon-controller/templates/volsync-addon-controller-deployment.yaml
+++ b/stable/volsync-addon-controller/templates/volsync-addon-controller-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.hubconfig.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ template "volsync-addon-controller.name" . }}


### PR DESCRIPTION
Instead of using the replicaCount from the hub config that is normally set to 2 (from the MCH availabilityConfig which is by default `high`), use a replicaCount of 1.

This is similar to the submariner addon controller and a few others.  Discussed with the installer team and it's ok for components who are not critical to set their own replicaCount.

The motivation for this is the VolSync addon controller is only needed to deploy volsync to managed clusters, and is not a mission critical multiclusterhub operator so no need for additional replicas normally.  On top of this, volsync is currently in tech preview.

Signed-off-by: Tesshu Flower <tflower@redhat.com>