### PR TITLE
Use proper kubernetes.io/arch matchExpression

### DIFF
--- a/stable/volsync-addon-controller/templates/volsync-addon-controller-deployment.yaml
+++ b/stable/volsync-addon-controller/templates/volsync-addon-controller-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 {{- range .Values.arch }}


### PR DESCRIPTION
- beta.kubernetes.io/arch has been deprecated for a long time

Signed-off-by: Tesshu Flower <tflower@redhat.com>